### PR TITLE
Add MIME version to register email

### DIFF
--- a/vendor/ValoaApplication/Controllers/Register/RegisterController.php
+++ b/vendor/ValoaApplication/Controllers/Register/RegisterController.php
@@ -196,6 +196,7 @@ class RegisterController extends \Webvaloa\Application
             $send = $mailer->setTo($email, $firstname . ' ' . $lastname)
                     ->setSubject(\Webvaloa\Webvaloa::translate('REGISTRATION_CONFIRM'))
                     ->setFrom($this->admin, $this->sitename)
+                    ->addGenericHeader('MIME-Version', '1.0')
                     ->addGenericHeader('X-Mailer', 'Webvaloa')
                     ->addGenericHeader('Content-Type', 'text/html; charset="utf-8"')
                     ->setMessage($this->message)


### PR DESCRIPTION
Adding MIME-Version: 1.0 to email header in Register controller so that it doesn't get blocked by most ISP's.
