### PR TITLE
Add support for transliterating in alias

### DIFF
--- a/vendor/Webvaloa/Article.php
+++ b/vendor/Webvaloa/Article.php
@@ -291,6 +291,11 @@ class Article
 
         $db = \Webvaloa\Webvaloa::DBConnection();
 
+        // Use transliteration to convert special letters and characters to ascii. Note: this requires setlocale with .UTF-8 to be correctly installed
+        $translit = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", $a);
+        if($translit !== false) {
+               $a = $translit;
+        }
         $a = preg_replace('/[^A-Za-z0-9\-]/', '', strtolower(str_replace(' ', '-', $a)));
 
         $query = '


### PR DESCRIPTION
Adds support for automatically transliterating special characters to human readable, URL safe format.
Example: ä -> a, € -> eur, etc.

This requires that setlocale is set to a .UTF-8 locale. And that locale must be installed on the system.
(This should always be the case, though.)
