### PR TITLE
Can not "use Webvaloa\Auth" in "namespace Webvaloa\Auth", duh

### DIFF
--- a/vendor/Webvaloa/Auth/Db.php
+++ b/vendor/Webvaloa/Auth/Db.php
@@ -31,7 +31,6 @@
  */
 namespace Webvaloa\Auth;
 
-use Webvaloa\Auth;
 use Webvaloa;
 use Webvaloa\Component;
 use Webvaloa\User;


### PR DESCRIPTION
Fixes:
PHP Fatal error:  Cannot use Webvaloa\Auth as Auth because the name is already in use
