### PR TITLE
Deny PHP files in /public/media

### DIFF
--- a/public/media/.htaccess
+++ b/public/media/.htaccess
@@ -1,1 +1,5 @@
 Options -Indexes 
+<FilesMatch "\.php$">
+  Order Allow,Deny
+  Deny from all
+</FilesMatch>


### PR DESCRIPTION
Doesn't allow users to upload and execute rogue PHP files...
