### PR TITLE
Deny access to the .cache file

### DIFF
--- a/public/cache/.htaccess
+++ b/public/cache/.htaccess
@@ -1,0 +1,4 @@
+<Files .cache>
+    order allow,deny
+    deny from all
+</Files>


### PR DESCRIPTION
Should not contain any confidential data, but there is no reason for users to access this file.
