### PR TITLE
Fix article association

### DIFF
--- a/vendor/ValoaApplication/Controllers/Content/ArticleController.php
+++ b/vendor/ValoaApplication/Controllers/Content/ArticleController.php
@@ -244,6 +244,13 @@ class ArticleController extends \Webvaloa\Application
             }
         }
 
+        // Test to see if we are trying to load an associated article
+        $preloadArticle = new Article($articleID);
+        if($preloadArticle->associated_content_id) {
+            // Redirect to the actual article
+            Redirect::to('content_article/edit/'.$preloadArticle->associated_content_id);
+        }
+
         // Try loading associated article
         $association = new ArticleAssociation($articleID);
         $association->setLocale(\Webvaloa\Webvaloa::getLocale());

--- a/vendor/ValoaApplication/Controllers/Content/SiteController.php
+++ b/vendor/ValoaApplication/Controllers/Content/SiteController.php
@@ -35,6 +35,7 @@ namespace ValoaApplication\Controllers\Content;
 use Webvaloa\Helpers\Navigation;
 use Webvaloa\Controller\Redirect;
 use Webvaloa\Article;
+use Webvaloa\Helpers\ArticleAssociation as ArticleHelper;
 use Webvaloa\Category;
 use stdClass;
 

--- a/vendor/ValoaApplication/Controllers/Content/SiteController.php
+++ b/vendor/ValoaApplication/Controllers/Content/SiteController.php
@@ -54,7 +54,16 @@ class SiteController extends \Webvaloa\Application
         $this->view->editablemenu->navigation = $navigation->get();
 
         $article = new Article(0);
-        $this->view->contents = $article->getArticles();
+        $articles = $article->getArticles();
+        $this->view->contents = array();
+        foreach($articles as $article) {
+            $articleHelper = new ArticleHelper((int) $article->id);
+            $associatedId=$articleHelper->getAssociatedId();
+            if($associatedId) {
+                $associatedArticle = new Article((int) $associatedId);
+                $this->view->contents[] = $associatedArticle;
+            }
+        }
 
         $query = '
             SELECT *

--- a/vendor/ValoaApplication/Controllers/Content/Views/Site.xsl
+++ b/vendor/ValoaApplication/Controllers/Content/Views/Site.xsl
@@ -116,8 +116,8 @@
 								<select class="select-type form-control">
 									<option value=""></option>
 									<xsl:for-each select="contents">
-										<option value="{id}">
-											<xsl:value-of select="title" />
+										<option value="{article/id}">
+											<xsl:value-of select="article/title" />
 										</option>
 									</xsl:for-each>
 								</select>


### PR DESCRIPTION
Use associated article IDs in site structure and the translated titles.
Also, redirect the users to the correct edit page when trying to open an associated article directly.