### PR TITLE
Fix undefined variable $overrides & $listOverrides

### DIFF
--- a/vendor/ValoaApplication/Controllers/Content/CategoryController.php
+++ b/vendor/ValoaApplication/Controllers/Content/CategoryController.php
@@ -137,6 +137,9 @@ class CategoryController extends \Webvaloa\Application
         if (!$id) {
             return false;
         }
+        
+        $overrides = array();
+        $listOverrides = array();
 
         $category = new Category((int) $id);
         $category->loadCategory();


### PR DESCRIPTION
When opening category settings undefined variable $overrides & $listOverrides.